### PR TITLE
Fix memory leak in asset loading

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ impl Transform {
         }
     }
     
-    pub fn with_rotation(&mut self, x: f32, y: f32, z: f32) -> Self {
+    pub fn with_rotation(&self, x: f32, y: f32, z: f32) -> Self {
         let translation = self.translation;
    
         Transform {

--- a/src/psp_assets.rs
+++ b/src/psp_assets.rs
@@ -123,7 +123,10 @@ impl Asset for Image {
             let (w, h, p, data) = load_png_swizzled(slice::from_raw_parts(handle as *const u8, fd.size as usize)).map_err(|e| IoError(format!("Could not load and swizzle the png: {}", e)))?;
             let t_d = AVec::from_slice(16, data.as_ref());
 
-            return Ok((w as usize, h as usize, p as usize, t_d)); 
+            // Free the temporary buffer holding the raw file data
+            dealloc(handle as *mut u8, layout);
+
+            return Ok((w as usize, h as usize, p as usize, t_d));
         }
     }
 }


### PR DESCRIPTION
## Summary
- free temporary file buffer when loading images
- make `Transform::with_rotation` take `&self` since the method does not mutate the struct

## Testing
- `cargo check` *(fails: `#![feature]` may not be used on the stable release channel)*

------
https://chatgpt.com/codex/tasks/task_e_683faff4ba38832782c9eb20f1b24cfc